### PR TITLE
Fixed MDI Icon

### DIFF
--- a/dryer_current.yaml
+++ b/dryer_current.yaml
@@ -34,7 +34,7 @@ sensor:
     sensor: adc_sensor
     name: "Dryer Current"
     unit_of_measurement: "A"
-    icon: "mdi:flash-circle"
+    icon: "mdi:lightning-bolt-circle"
     id: dryer_current
     update_interval: 20s
     filters:


### PR DESCRIPTION
Changed icon to mdi_lightning-bolt-circle as mdi:flash-circle is deprecated.